### PR TITLE
arbiter: Try always respect the graceful_timeout setting

### DIFF
--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -41,7 +41,6 @@ class Arbiter:
     SIG_QUEUE = queue.SimpleQueue()
     SIGNALS = [getattr(signal.Signals, "SIG%s" % x)
                for x in "CHLD HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
-    SIG_NAMES = dict((sig, sig.name[3:].lower()) for sig in SIGNALS)
 
     def __init__(self, app):
         os.environ["SERVER_SOFTWARE"] = SERVER_SOFTWARE
@@ -70,6 +69,11 @@ class Arbiter:
             "cwd": cwd,
             0: sys.executable
         }
+
+        self.SIG_HANDLERS = dict(
+            (sig, getattr(self, "handle_%s" % sig.name[3:].lower()))
+            for sig in self.SIGNALS
+        )
 
     def _get_num_workers(self):
         return self._num_workers
@@ -193,18 +197,11 @@ class Arbiter:
 
                 try:
                     sig = self.SIG_QUEUE.get(timeout=1)
-                except queue.Empty:
-                    sig = None
-
-                if sig:
-                    signame = self.SIG_NAMES.get(sig)
-                    handler = getattr(self, "handle_%s" % signame, None)
-                    if not handler:
-                        self.log.error("Unhandled signal: %s", signame)
-                        continue
                     if sig != signal.SIGCHLD:
-                        self.log.info("Handling signal: %s", signame)
-                    handler()
+                        self.log.info("Handling signal: %s", signal.Signals(sig).name)
+                    self.SIG_HANDLERS[sig]()
+                except queue.Empty:
+                    pass
 
                 self.murder_workers()
                 self.manage_workers()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -41,6 +41,7 @@ class Arbiter:
     SIG_QUEUE = queue.SimpleQueue()
     SIGNALS = [getattr(signal.Signals, "SIG%s" % x)
                for x in "CHLD HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
+    WAKEUP_REQUEST = signal.NSIG
 
     def __init__(self, app):
         os.environ["SERVER_SOFTWARE"] = SERVER_SOFTWARE
@@ -178,11 +179,17 @@ class Arbiter:
 
     def signal(self, sig, frame):
         """ Note: Signal handler! No logging allowed. """
-        self.SIG_QUEUE.put(sig)
+        self.wakeup(due_to_signal=sig)
 
         # Some UNIXes require SIGCHLD to be reinstalled, see python signal docs
         if sig == signal.SIGCHLD:
             signal.signal(sig, self.signal)
+
+    def wakeup(self, due_to_signal=None):
+        """\
+        Wake up the main master loop.
+        """
+        self.SIG_QUEUE.put(due_to_signal or self.WAKEUP_REQUEST)
 
     def run(self):
         "Main master loop."
@@ -197,9 +204,10 @@ class Arbiter:
 
                 try:
                     sig = self.SIG_QUEUE.get(timeout=1)
-                    if sig != signal.SIGCHLD:
-                        self.log.info("Handling signal: %s", signal.Signals(sig).name)
-                    self.SIG_HANDLERS[sig]()
+                    if sig != self.WAKEUP_REQUEST:
+                        if sig != signal.SIGCHLD:
+                            self.log.info("Handling signal: %s", signal.Signals(sig).name)
+                        self.SIG_HANDLERS[sig]()
                 except queue.Empty:
                     pass
 

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -470,44 +470,38 @@ class Arbiter:
                     break
                 if self.reexec_pid == wpid:
                     self.reexec_pid = 0
-                else:
-                    # A worker was terminated. If the termination reason was
-                    # that it could not boot, we'll shut it down to avoid
-                    # infinite start/stop cycles.
-                    exitcode = status >> 8
-                    if exitcode != 0:
-                        self.log.error('Worker (pid:%s) exited with code %s', wpid, exitcode)
+                    continue
+
+                if os.WIFEXITED(status):
+                    # A worker was normally terminated. If the termination
+                    # reason was that it could not boot, we'll halt the server
+                    # to avoid infinite start/stop cycles.
+                    exitcode = os.WEXITSTATUS(status)
+                    log = self.log.error if exitcode != 0 else self.log.debug
+                    log('Worker (pid:%s) exited with code %s', wpid, exitcode)
                     if exitcode == self.WORKER_BOOT_ERROR:
                         reason = "Worker failed to boot."
                         raise HaltServer(reason, self.WORKER_BOOT_ERROR)
                     if exitcode == self.APP_LOAD_ERROR:
                         reason = "App failed to load."
                         raise HaltServer(reason, self.APP_LOAD_ERROR)
+                elif os.WIFSIGNALED(status):
+                    # A worker was terminated by a signal.
+                    sig = os.WTERMSIG(status)
+                    try:
+                        sig_name = signal.Signals(sig).name
+                    except ValueError:
+                        sig_name = "signal {}".format(sig)
+                    msg = "Worker (pid:{}) was terminated by {}!".format(
+                        wpid, sig_name)
 
-                    if exitcode > 0:
-                        # If the exit code of the worker is greater than 0,
-                        # let the user know.
-                        self.log.error("Worker (pid:%s) exited with code %s.",
-                                       wpid, exitcode)
-                    elif status > 0:
-                        # If the exit code of the worker is 0 and the status
-                        # is greater than 0, then it was most likely killed
-                        # via a signal.
-                        try:
-                            sig_name = signal.Signals(status).name
-                        except ValueError:
-                            sig_name = "code {}".format(status)
-                        msg = "Worker (pid:{}) was sent {}!".format(
-                            wpid, sig_name)
+                    # Additional hint for SIGKILL
+                    if sig == signal.SIGKILL:
+                        msg += " Perhaps out of memory?"
+                    self.log.error(msg)
 
-                        # Additional hint for SIGKILL
-                        if status == signal.SIGKILL:
-                            msg += " Perhaps out of memory?"
-                        self.log.error(msg)
-
-                    worker = self.WORKERS.pop(wpid, None)
-                    if not worker:
-                        continue
+                worker = self.WORKERS.pop(wpid, None)
+                if worker:
                     worker.tmp.close()
                     self.cfg.child_exit(self, worker)
         except OSError as e:

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -4,11 +4,11 @@
 import errno
 import os
 import random
-import select
 import signal
 import sys
 import time
 import traceback
+import queue
 
 from gunicorn.errors import HaltServer, AppImportError
 from gunicorn.pidfile import Pidfile
@@ -36,10 +36,9 @@ class Arbiter:
 
     LISTENERS = []
     WORKERS = {}
-    PIPE = []
 
     # I love dynamic languages
-    SIG_QUEUE = []
+    SIG_QUEUE = queue.SimpleQueue()
     SIGNALS = [getattr(signal.Signals, "SIG%s" % x)
                for x in "CHLD HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
     SIG_NAMES = dict((sig, sig.name[3:].lower()) for sig in SIGNALS)
@@ -167,16 +166,6 @@ class Arbiter:
         Initialize master signal handling. Most of the signals
         are queued. Child signals only wake up the master.
         """
-        # close old PIPE
-        for p in self.PIPE:
-            os.close(p)
-
-        # initialize the pipe
-        self.PIPE = pair = os.pipe()
-        for p in pair:
-            util.set_non_blocking(p)
-            util.close_on_exec(p)
-
         self.log.close_on_exec()
 
         # initialize all signals
@@ -184,9 +173,8 @@ class Arbiter:
             signal.signal(s, self.signal)
 
     def signal(self, sig, frame):
-        if len(self.SIG_QUEUE) < 5:
-            self.SIG_QUEUE.append(sig)
-            self.wakeup()
+        """ Note: Signal handler! No logging allowed. """
+        self.SIG_QUEUE.put(sig)
 
     def run(self):
         "Main master loop."
@@ -199,26 +187,23 @@ class Arbiter:
             while True:
                 self.maybe_promote_master()
 
-                sig = self.SIG_QUEUE.pop(0) if self.SIG_QUEUE else None
-                if sig is None:
-                    self.sleep()
-                    self.murder_workers()
-                    self.manage_workers()
-                    continue
+                try:
+                    sig = self.SIG_QUEUE.get(timeout=1)
+                except queue.Empty:
+                    sig = None
 
-                if sig not in self.SIG_NAMES:
-                    self.log.info("Ignoring unknown signal: %s", sig)
-                    continue
+                if sig:
+                    signame = self.SIG_NAMES.get(sig)
+                    handler = getattr(self, "handle_%s" % signame, None)
+                    if not handler:
+                        self.log.error("Unhandled signal: %s", signame)
+                        continue
+                    if sig != signal.SIGCHLD:
+                        self.log.info("Handling signal: %s", signame)
+                    handler()
 
-                signame = self.SIG_NAMES.get(sig)
-                handler = getattr(self, "handle_%s" % signame, None)
-                if not handler:
-                    self.log.error("Unhandled signal: %s", signame)
-                    continue
-                if sig != signal.SIGCHLD:
-                    self.log.info("Handling signal: %s", signame)
-                handler()
-                self.wakeup()
+                self.murder_workers()
+                self.manage_workers()
         except (StopIteration, KeyboardInterrupt):
             self.halt()
         except HaltServer as inst:
@@ -322,16 +307,6 @@ class Arbiter:
             # reset proctitle
             util._setproctitle("master [%s]" % self.proc_name)
 
-    def wakeup(self):
-        """\
-        Wake up the arbiter by writing to the PIPE
-        """
-        try:
-            os.write(self.PIPE[1], b'.')
-        except OSError as e:
-            if e.errno not in [errno.EAGAIN, errno.EINTR]:
-                raise
-
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
         self.stop()
@@ -345,25 +320,6 @@ class Arbiter:
             self.pidfile.unlink()
         self.cfg.on_exit(self)
         sys.exit(exit_status)
-
-    def sleep(self):
-        """\
-        Sleep until PIPE is readable or we timeout.
-        A readable PIPE means a signal occurred.
-        """
-        try:
-            ready = select.select([self.PIPE[0]], [], [], 1.0)
-            if not ready[0]:
-                return
-            while os.read(self.PIPE[0], 1):
-                pass
-        except OSError as e:
-            # TODO: select.error is a subclass of OSError since Python 3.3.
-            error_number = getattr(e, 'errno', e.args[0])
-            if error_number not in [errno.EAGAIN, errno.EINTR]:
-                raise
-        except KeyboardInterrupt:
-            sys.exit()
 
     def stop(self, graceful=True):
         """\
@@ -387,11 +343,9 @@ class Arbiter:
         # instruct the workers to exit
         self.kill_workers(sig)
         # wait until the graceful timeout
-        while True:
-            self.reap_workers()
-            if not self.WORKERS or time.time() >= limit:
-                break
+        while self.WORKERS and time.time() < limit:
             time.sleep(0.1)
+            self.reap_workers()
 
         self.kill_workers(signal.SIGKILL)
 

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -176,6 +176,10 @@ class Arbiter:
         """ Note: Signal handler! No logging allowed. """
         self.SIG_QUEUE.put(sig)
 
+        # Some UNIXes require SIGCHLD to be reinstalled, see python signal docs
+        if sig == signal.SIGCHLD:
+            signal.signal(sig, self.signal)
+
     def run(self):
         "Main master loop."
         self.start()

--- a/gunicorn/arbiter.py
+++ b/gunicorn/arbiter.py
@@ -40,12 +40,9 @@ class Arbiter:
 
     # I love dynamic languages
     SIG_QUEUE = []
-    SIGNALS = [getattr(signal, "SIG%s" % x)
-               for x in "HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
-    SIG_NAMES = dict(
-        (getattr(signal, name), name[3:].lower()) for name in dir(signal)
-        if name[:3] == "SIG" and name[3] != "_"
-    )
+    SIGNALS = [getattr(signal.Signals, "SIG%s" % x)
+               for x in "CHLD HUP QUIT INT TERM TTIN TTOU USR1 USR2 WINCH".split()]
+    SIG_NAMES = dict((sig, sig.name[3:].lower()) for sig in SIGNALS)
 
     def __init__(self, app):
         os.environ["SERVER_SOFTWARE"] = SERVER_SOFTWARE
@@ -185,7 +182,6 @@ class Arbiter:
         # initialize all signals
         for s in self.SIGNALS:
             signal.signal(s, self.signal)
-        signal.signal(signal.SIGCHLD, self.handle_chld)
 
     def signal(self, sig, frame):
         if len(self.SIG_QUEUE) < 5:
@@ -219,7 +215,8 @@ class Arbiter:
                 if not handler:
                     self.log.error("Unhandled signal: %s", signame)
                     continue
-                self.log.info("Handling signal: %s", signame)
+                if sig != signal.SIGCHLD:
+                    self.log.info("Handling signal: %s", signame)
                 handler()
                 self.wakeup()
         except (StopIteration, KeyboardInterrupt):
@@ -236,10 +233,9 @@ class Arbiter:
                 self.pidfile.unlink()
             sys.exit(-1)
 
-    def handle_chld(self, sig, frame):
+    def handle_chld(self):
         "SIGCHLD handling"
         self.reap_workers()
-        self.wakeup()
 
     def handle_hup(self):
         """\
@@ -391,7 +387,10 @@ class Arbiter:
         # instruct the workers to exit
         self.kill_workers(sig)
         # wait until the graceful timeout
-        while self.WORKERS and time.time() < limit:
+        while True:
+            self.reap_workers()
+            if not self.WORKERS or time.time() >= limit:
+                break
             time.sleep(0.1)
 
         self.kill_workers(signal.SIGKILL)

--- a/gunicorn/workers/base.py
+++ b/gunicorn/workers/base.py
@@ -49,8 +49,8 @@ class Worker:
         self.timeout = timeout
         self.cfg = cfg
         self.booted = False
-        self.aborted = False
         self.reloader = None
+        self.termination_deadline = None
 
         self.nr = 0
 


### PR DESCRIPTION
Previously, a worker could be sent a second signal of the same type within the graceful timeout, and that could lead to trouble if the worker had already terminated; the worker would indicate that it'd got terminated by a signal rather than saying that it exited gracefully.